### PR TITLE
Logger fixes

### DIFF
--- a/pytorch_pfn_extras/logging.py
+++ b/pytorch_pfn_extras/logging.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL  # NOQA
+
 _logger_name = 'ppe'
 _logger_format = '[%(name)s] %(asctime)s: (%(levelname)s) %(message)s'
 _logger = None

--- a/pytorch_pfn_extras/logging.py
+++ b/pytorch_pfn_extras/logging.py
@@ -2,20 +2,22 @@ import logging
 import os
 
 _logger_name = 'ppe'
+_logger_format = '[%(name)s] %(asctime)s: (%(levelname)s) %(message)s'
 _logger = None
 
 
-def _configure_logging():
+def _configure_logging(*, filename=None, level='ERROR', format=_logger_format):
     global _logger
-    filename = os.environ.get('PPE_LOG_FILENAME', None)
+    filename = os.environ.get('PPE_LOG_FILENAME', filename)
     if filename is None:
         handler = logging.StreamHandler()
     else:
         handler = logging.FileHandler(filename)
+    handler.setFormatter(logging.Formatter(format))
     # To dynamically change the level if needed
     # basicConfig does not allow to change the level right after
     _logger = logging.getLogger(_logger_name)
-    level = os.environ.get('PPE_LOG_LEVEL', 'ERROR')
+    level = os.environ.get('PPE_LOG_LEVEL', level)
     for lvl in (logging.DEBUG, logging.INFO,
                 logging.WARNING, logging.ERROR, logging.CRITICAL):
         if logging.getLevelName(lvl) == level:
@@ -27,8 +29,11 @@ def _configure_logging():
     _logger.addHandler(handler)
 
 
-def get_logger(name=None):
-    if name is None:
-        return _logger
-    else:
-        return _logger.getChild(name)
+def _get_root_logger():
+    """Returns a logger to be used by pytorch-pfn-extras."""
+    return _logger
+
+
+def get_logger(name):
+    """Returns a child logger to be used by applications."""
+    return _logger.getChild(name)

--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -7,7 +7,7 @@ from pytorch_pfn_extras import logging
 from pytorch_pfn_extras.training import extension
 
 
-logger = logging.get_logger()
+logger = logging._get_root_logger()
 
 
 def _find_snapshot_files(fmt, path, fs):

--- a/tests/pytorch_pfn_extras_tests/test_logging.py
+++ b/tests/pytorch_pfn_extras_tests/test_logging.py
@@ -1,0 +1,22 @@
+import tempfile
+
+from pytorch_pfn_extras import logging
+
+
+def test_file_output():
+    try:
+        with tempfile.NamedTemporaryFile() as logfile:
+            logging._configure_logging(filename=logfile.name, level='DEBUG')
+            logger = logging._get_root_logger()
+            logger.info('TEST LOG MESSAGE')
+            with open(logfile.name) as f:
+                assert 'TEST LOG MESSAGE' in f.read()
+    finally:
+        logging._configure_logging()
+
+
+def test_get_logger():
+    logger = logging.get_logger('app')
+    logger.setLevel(logging.DEBUG)
+    assert logger.name == 'ppe.app'
+    assert logger.level == logging.DEBUG


### PR DESCRIPTION
* Export logger constants so that users can use it without importing `logging` module
* Expose `ppe.logging.get_logger()` as an API for enduser applications
* Set log format to include date and log level
* Changed `_configure_logging` signature (sorry to reverting my comment, I think it's better to have it for unit testing)
* Add unit tests